### PR TITLE
Fix _config.yml: site url, author bio, duplicate pagination block

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -22,7 +22,7 @@ title_separator          : "-"
 subtitle                 : # site tagline that appears below site title in masthead
 name                     : 
 description              : "Investigations of oceanic and atmospheric turbulence"
-url                      : #"https://tomchor.github.io"
+url                      : "https://tomchor.github.io"
 baseurl                  : # Subpath, if there is one.
 repository               : "tomchor/tomchor.github.io"
 teaser                   : #
@@ -114,7 +114,7 @@ analytics:
 author:
   name             : "Tomás L. Chor"
   avatar           : "/assets/images/TChor-02p_UCLA_cropped.jpg"
-  bio              : "<br>"
+  bio              : "Geophysical fluid dynamicist studying turbulence at UMD AOSC and atdepth MRV"
 #  location         : "Los Angeles | São Paulo"
   email            : #"contact@tomaschor.xyz"
   links:
@@ -236,32 +236,6 @@ sass:
 # Outputting
 permalink: /:categories/:title/
 timezone: # https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
-
-# Pagination with jekyll-paginate
-paginate: 5 # amount of posts to show
-paginate_path: /page:num/
-
-# Pagination with jekyll-paginate-v2
-# See https://github.com/sverrirs/jekyll-paginate-v2/blob/master/README-GENERATOR.md#site-configuration
-#   for configuration details
-pagination:
-  # Set enabled to true to use paginate v2
-  # enabled: true
-  debug: false
-  collection: 'posts'
-  per_page: 10
-  permalink: '/page/:num/'
-  title: ':title - page :num'
-  limit: 0
-  sort_field: 'date'
-  sort_reverse: true
-  category: 'posts'
-  tag: ''
-  locale: ''
-  trail:
-    before: 2
-    after: 2
-
 
 # Pagination with jekyll-paginate
 paginate: 5 # amount of posts to show


### PR DESCRIPTION
## Summary
- Set `url` to `https://tomchor.github.io` (was commented out, so jekyll-sitemap, jekyll-feed, and SEO meta tags emitted broken/missing absolute URLs).
- Replaced placeholder author `bio` (`<br>`) with a one-line description so the sidebar has context under the name.
- Removed a duplicated `paginate`/`pagination` block that was identical to the one above it.

## Notes
- The bio text — _"Geophysical fluid dynamicist studying turbulence at UMD AOSC and atdepth MRV"_ — was inferred from `index.md`. Edit before merging if the wording or affiliation isn't quite right.

## Test plan
- [ ] `bundle exec jekyll serve` and confirm the site builds without warnings.
- [ ] Confirm the bio line shows under the avatar in the sidebar.
- [ ] View page source on any built page and confirm `<link rel="canonical">` and og:url use the absolute https://tomchor.github.io URL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)